### PR TITLE
resize project card image

### DIFF
--- a/themes/gatsby-theme-minimal-portfolio/src/components/project-card.js
+++ b/themes/gatsby-theme-minimal-portfolio/src/components/project-card.js
@@ -31,9 +31,6 @@ const ProjectCard = ({title, link, bg, textColor, thumbnailPath, children}) => (
                         textAlign: 'center'
                     }}>
                         <Image
-                            sx={{
-                                maxWidth: "100%"
-                            }}
                             src={thumbnailPath}/>
                     </Box>
                 }

--- a/themes/gatsby-theme-minimal-portfolio/src/components/project-card.js
+++ b/themes/gatsby-theme-minimal-portfolio/src/components/project-card.js
@@ -26,12 +26,13 @@ const ProjectCard = ({title, link, bg, textColor, thumbnailPath, children}) => (
             >
 
                 {thumbnailPath &&
+
                     <Box sx={{
                         textAlign: 'center'
                     }}>
                         <Image
                             sx={{
-                                maxWidth: "500px"
+                                maxWidth: "100%"
                             }}
                             src={thumbnailPath}/>
                     </Box>


### PR DESCRIPTION
Here I replace 500px specification in project-card.js instead to 100% so the images scale with the screen sizes. 

fixes #3 